### PR TITLE
Remove !important from .alignfull

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ const tailwind = plugin(function ({addUtilities, addComponents, e, prefix, confi
 
     const alignmentUtilities = {
         '.alignfull': {
-            margin: `${margin[8] || '0.5rem'} calc(50% - 50vw) !important`,
-            maxWidth: '100vw !important',
+            margin: `${margin[8] || '0.5rem'} calc(50% - 50vw)`,
+            maxWidth: '100vw',
             "@apply w-screen": {}
         },
         '.alignwide': {


### PR DESCRIPTION
Hi @jeffreyvr 

Thanks a lot for your wonderful tailpress, it is working like a charm and i started using it for a second project.

This PR is very small and just removes the `!important` statement for the class `.alignfull`
I think this is too opinionated and does not follow the tailwind style guide. As I'd like to rely on a custom grid system I need to overwrite the current definitions with another important, which leads to another important and so on...

I hope does not trigger sideeffects on the current implementation. Another idea would be to change the selectors to match the default wordpress one and use selectors like `:where(body .alignfull)`.

Greets