### PR TITLE
Allow for FSE Style Editor Colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const colorMapper = (colors) => {
     let result = {};
 
     colors.forEach(function(color) {
-        result[''+color.slug+''] = color.color;
+         result[''+color.slug+''] = 'var(--wp--preset--color--'+color.slug+')';
     });
 
     return result;


### PR DESCRIPTION
When working with a FSE theme, I noticed the custom Tailwind color classes were using the theme.json colors instead of colors selected by the new WP Style Variations or Style Editor. 

The FSE Style Editor saves theme changes to the database, which means any edits done in the Style Editor won't show in theme.json. 

This change just uses the CSS variables created by WP based on the theme.json colors. 
The variables respect the colors saved to the DB by the Style Editor.